### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/src/main/java/com/github/boneill42/model/Product.java
+++ b/src/main/java/com/github/boneill42/model/Product.java
@@ -50,7 +50,7 @@ public class Product implements Serializable {
     }
     
     public static List<String> columns() {
-        List<String> columns = new ArrayList<String>();
+        List<String> columns = new ArrayList<>();
         columns.add("id");
         columns.add("name");
         columns.add("parents"); 

--- a/src/main/java/com/github/boneill42/model/Sale.java
+++ b/src/main/java/com/github/boneill42/model/Sale.java
@@ -52,7 +52,7 @@ public class Sale implements Serializable {
     }
     
     public static List<String> columns() {
-        List<String> columns = new ArrayList<String>();
+        List<String> columns = new ArrayList<>();
         columns.add("id");
         columns.add("product");
         columns.add("price");

--- a/src/main/java/com/github/boneill42/model/Summary.java
+++ b/src/main/java/com/github/boneill42/model/Summary.java
@@ -41,7 +41,7 @@ public class Summary implements Serializable {
     }
     
     public static List<String> columns() {
-        List<String> columns = new ArrayList<String>();
+        List<String> columns = new ArrayList<>();
         columns.add("product");
         columns.add("summary");
         return columns;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.
